### PR TITLE
Fixing tier calculation in back-to-first case

### DIFF
--- a/cmd/calculation-api/main.go
+++ b/cmd/calculation-api/main.go
@@ -90,8 +90,6 @@ func Calculate(c echo.Context) error {
 	var bodyBytes []byte
 	if c.Request().Body != nil {
 		bodyBytes, _ = ioutil.ReadAll(c.Request().Body)
-		fmt.Println("=========Input Data Start======\n", string(bodyBytes))
-		fmt.Println("=========Input Data End======")
 	}
 
 	var request models.CalculateRequest


### PR DESCRIPTION
In the case of back-to-first kind, the threshold limits were not honored. This fix makes the code adhere to pick up price (fixed+linear) from the right threshold.