### PR TITLE
switch to golang:alpine3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine3.13
+FROM golang:1.15-alpine3.14
 
 COPY . /app
 


### PR DESCRIPTION
A newer golang image is available that fixes CVE-2021-36159.

Does not fix CVE-2021-3711 which remains unresolved.